### PR TITLE
Auto update colorschemes with base16-builder-go

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @base16-project/putty

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -1,0 +1,24 @@
+name: Update with the latest colorschemes
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * 0" # https://crontab.guru/every-week
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch the repository code
+        uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.BOT_ACCESS_TOKEN }}
+      - name: Update schemes
+        uses: base16-project/base16-builder-go@latest
+      - name: Commit the changes, if any
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: Update with the latest base16-project colorschemes
+          branch: ${{ github.head_ref }}
+          commit_user_name: base16-project-bot
+          commit_user_email: base16themeproject@proton.me
+          commit_author: base16-project-bot <base16themeproject@proton.me>

--- a/.gitignore
+++ b/.gitignore
@@ -1,15 +1,1 @@
-+*
-
-# Created by https://www.gitignore.io/api/vim
-
-### Vim ###
-# swap
-[._]*.s[a-w][a-z]
-[._]s[a-w][a-z]
-# session
-Session.vim
-# temporary
-.netrwhist
-*~
-# auto-generated tag files
-tags
+schemes

--- a/README.md
+++ b/README.md
@@ -7,12 +7,8 @@ Base16 colors for PuTTY
 Introduction
 ------------
 
-This project provides `.reg` files for configuring PuTTY colors according to
-the `base16 system`, originally created by
-[Chris Kempson](https://github.com/chriskempson/base16).
-
-This repository is based on @staticland's [original work](https://github.com/staticaland/base16-putty),
-by adding a template that can be used to rebuild the themes.
+This project provides `.reg` files for configuring PuTTY colors
+according to the `base16 system`.
 
 
 Usage
@@ -28,11 +24,17 @@ Usage
 5. Edit the file, and change session name in
    `[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\` **`{{SESSION_NAME}}`** `]`
    to the session you would like to apply the theme;
-6. Run the file and accept it make changes in Windows Registry...
+6. Run the file and accept it to make changes in Windows Registry.
 
 
-Rebuild
--------
+Issues or Contributions
+------------------------
+
+This repo rebuilds the colorschemes every week, so make sure to pull to
+keep up to date with the latest changes.
+
+If you're you're looking to build the colorschemes manually to test out
+a change:
 
 1. Install [base16-builder-go](https://github.com/base16-project/base16-builder-go)
    or a compatible tool.
@@ -41,23 +43,13 @@ Rebuild
    contains pre-built binaries that can be simply downloaded and executed).
 2. Execute the `builder` binary from the `base16-putty` directory.
    In the case of `base16-builder-go` no argument is required.
-3. Check if updates took place (new/modified files are placed inside the `putty` directory)...
+3. Check if updates took place (new/modified files are placed inside the `/putty` directory).
 
-
-Issues or Contributions
-------------------------
-
-Please have a look on [these guides](https://opensource.guide/how-to-contribute/) for more information.
-
+Have a look at [these guides](https://opensource.guide/how-to-contribute/) for more information.
 
 Thanks
 ------
 
-- @staticaland for the [original material](https://github.com/staticaland/base16-putty)
-  (I would never find out about the `.reg` files...);
-- @iamthad and @ticky for [mapping](https://github.com/iamthad/base16-mintty)
-  `base16` vars into color names used by PuTTY;
-- @chriskempson for the [base16 project](https://github.com/chriskempson/base16)
-  and [builder](https://github.com/chriskempson/base16-builder-php)
-- The community behind [`base16-builder-go`](https://github.com/base16-project/base16-builder-go)
-  and other `base16`/`base16`-inspired tools and schemes.
+- @staticaland for the [original material](https://github.com/staticaland/base16-putty);
+- @iamthad and @ticky for [mapping](https://github.com/iamthad/base16-mintty) `base16` vars into color names used by PuTTY;
+- @chriskempson for the original conception of the [base16 project](https://github.com/base16-project/home).


### PR DESCRIPTION
Add feature to automatically build themes every week via a github action. If a new scheme is added to the [schemes](https://github.com/base16-project/base16-schemes) repo, this change will be automatically added and committed to the repo.

- Add codeowners file to automatically tag the putty maintainers whenever a new PR or issue is created. 
- Move "rebuild" section into "contribution" section of the readme since there is no reason to rebuild unless someone is contributing.
- Adjust readme slightly to reflect that it's now an organization repo and not a personal repo.

Note: I've done one more rebase on the `main` branch (so make sure to update your local branch with a `git reset --hard origin/main` or something similar). I've included the original commits from https://github.com/staticaland/base16-putty. It's also why I removed the reference from the readme.